### PR TITLE
Use stretch alignment in Columns

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -616,7 +616,7 @@ class _FlushbarState<K extends Object> extends State<Flushbar> with TickerProvid
         new Expanded(
           flex: 1,
           child: new Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               (_isTitlePresent)
@@ -643,7 +643,7 @@ class _FlushbarState<K extends Object> extends State<Flushbar> with TickerProvid
         new Expanded(
           flex: 1,
           child: new Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               (_isTitlePresent)
@@ -666,7 +666,7 @@ class _FlushbarState<K extends Object> extends State<Flushbar> with TickerProvid
         new Expanded(
           flex: 1,
           child: new Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               (_isTitlePresent)
@@ -694,7 +694,7 @@ class _FlushbarState<K extends Object> extends State<Flushbar> with TickerProvid
         new Expanded(
           flex: 1,
           child: new Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               (_isTitlePresent)


### PR DESCRIPTION
This fixes #15. Verified locally by just dropping `flushbar.dart` into my local project. The default behaviour is the same, but it allows `textAlign` in `messageText` to function correctly. 