### PR TITLE
Check if the route exists before calling isDismissed or isShowing

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -392,6 +392,11 @@ class Flushbar<T extends Object> extends StatefulWidget {
   /// Dismisses the flushbar causing is to return a future containing [result].
   /// When this future finishes, it is guaranteed that Flushbar was dismissed.
   Future<T> dismiss([T result]) async {
+    // If route was never initialized, do nothing
+    if (_flushbarRoute == null) {
+      return null;
+    }
+
     if (_flushbarRoute.isCurrent) {
       _flushbarRoute.navigator.pop(result);
       return _flushbarRoute.completed;
@@ -407,12 +412,12 @@ class Flushbar<T extends Object> extends StatefulWidget {
 
   /// Checks if the flushbar is visible
   bool isShowing() {
-    return _flushbarRoute.currentStatus == FlushbarStatus.SHOWING;
+    return _flushbarRoute?.currentStatus == FlushbarStatus.SHOWING;
   }
 
   /// Checks if the flushbar is dismissed
   bool isDismissed() {
-    return _flushbarRoute.currentStatus == FlushbarStatus.DISMISSED;
+    return _flushbarRoute?.currentStatus == FlushbarStatus.DISMISSED;
   }
 
   @override

--- a/test/flushbar_test.dart
+++ b/test/flushbar_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('Test Flushbar basic inicialization', () {
+  test('Test Flushbar basic inicialization', () async {
     final flushbar = new Flushbar(message: "This is a test");
     expect(flushbar.title, null);
     expect(flushbar.message, "This is a test");
@@ -26,7 +26,10 @@ void main() {
     expect(flushbar.progressIndicatorController, null);
     expect(flushbar.progressIndicatorBackgroundColor, null);
     expect(flushbar.progressIndicatorValueColor, null);
+    expect(flushbar.isShowing(), false);
+    expect(flushbar.isDismissed(), false);
+    expect(await flushbar.dismiss(), null);
   });
 
-  
+
 }


### PR DESCRIPTION
Check if the route exists before calling `isDismissed` or `isShowing`.