### PR TITLE
Navigator and Theme as parameters 

### DIFF
--- a/lib/flushbar.dart
+++ b/lib/flushbar.dart
@@ -215,12 +215,19 @@ class Flushbar<T extends Object> extends StatefulWidget {
 
   /// Show the flushbar. Kicks in [FlushbarStatus.IS_APPEARING] state followed by [FlushbarStatus.SHOWING]
   Future<T> show(BuildContext context) async {
-    _flushbarRoute = route.showFlushbar<T>(
-      context: context,
-      flushbar: this,
+    return showWithoutContext(
+        themeData: Theme.of(context),
+        navigatorState: Navigator.of(context, rootNavigator: false),
     );
+  }
 
-    return await Navigator.of(context, rootNavigator: false).push(_flushbarRoute);
+  Future<T> showWithoutContext({@required ThemeData themeData, @required NavigatorState navigatorState}) async {
+    _flushbarRoute = route.FlushbarRoute<T>(
+      flushbar: this,
+      theme: themeData,
+      settings: RouteSettings(name: FLUSHBAR_ROUTE_NAME),
+    );
+     return navigatorState.push(_flushbarRoute);
   }
 
   /// Dismisses the flushbar causing is to return a future containing [result].


### PR DESCRIPTION
It is necessary for the possibility of using the flashbar on all pages.
Ex:
```
BlocListener<MessagesBloc, MessagesState>(
            listener: (context, state) {
                Flushbar flush;
                flush = Flushbar<bool>(
                  title: state.title,
                  message: state.text,
                  duration: state.duration,
                  mainButton: FlatButton(
                    onPressed: () => flush.dismiss(true),
                    child: Text(S.current.okButtonLabel),
                  ),
                )..showWithoutContext(
                  navigatorState: _navigatorKey.currentState,
                  themeData: Theme.of(_navigatorKey.currentContext),
                );
              }
            },
          )
        ],
        child: MaterialApp(
                navigatorKey: _navigatorKey,
                ...
```