### PR TITLE
lib/flushbar_route.dart -> install() add required arguments OverlayEntry insertion…

### DIFF
--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -300,7 +300,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
   }
 
   @override
-  void install() {
+  void install(OverlayEntry insertionPoint) {
     assert(!_transitionCompleter.isCompleted, 'Cannot install a $runtimeType after disposing it.');
     _controller = createAnimationController();
     assert(_controller != null, '$runtimeType.createAnimationController() returned null.');
@@ -308,7 +308,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
     _filterColorAnimation = createColorFilterAnimation();
     _animation = createAnimation();
     assert(_animation != null, '$runtimeType.createAnimation() returned null.');
-    super.install();
+    super.install(insertionPoint);
   }
 
   @override


### PR DESCRIPTION
…Point as per required in overriding OverlayRoute

adding required argument OverlayEntry on override install method 
to prevent error when running in  Flutter 1.12.13+hotfix.8 • channel stable 
like following : 
`
lib/flushbar_route.dart:303:8: Error: The method 'FlushbarRoute.install' has fewer positional arguments than those of overridden method 'OverlayRoute.install'.
  void install() {                                                      
       ^                                                                
../../IDE/flutter/packages/flutter/lib/src/widgets/routes.dart:41:8: Context: This is the overridden method ('install').
  void install(OverlayEntry insertionPoint) {                           
       ^                                                                
../../IDE/flutter/.pub-cache/git/flushbar-58b6ba2872503813fe8aa5a843d99e5f7af9b97c/lib/flushbar_route.dart:311:18: Error: Too few positional arguments: 1 required, 0 given.
    super.install();                                                    
                 ^   `                                              
Target kernel_snapshot failed: Exception: Errors during snapshot creation: null
build failed.                                                           
                                                                        
FAILURE: Build failed with an exception.                                
`
